### PR TITLE
Feature: Highlight All Non-Overlapping Regex Matches on a LineEnhanced match highlighting.

### DIFF
--- a/test_all_matches.txt
+++ b/test_all_matches.txt
@@ -1,0 +1,3 @@
+This line has some text.
+And more text on this line.
+No match here.


### PR DESCRIPTION
# Description
This PR introduces a significant enhancement to our regex matching tool: the ability to highlight all non-overlapping occurrences of a matched pattern within a single line of text, rather than just the first one.
Previously, if a line contained multiple matches for a given regex, only the first match found was highlighted. This update provides a more comprehensive visual output, allowing users to quickly identify every instance of a pattern within a matched line.

# Key Changes
## MatchInfo Struct Update
The MatchInfo struct has been modified to store a std::vector<std::pair<size_t, size_t>> named matches. Each pair represents the (start_position, end_position) of a non-overlapping match found on the line.
The bool found member is retained to indicate if any matches were found on the line.
code

Before:
```
// struct MatchInfo {
//     bool found;
//     size_t start_pos;
//     size_t end_pos;
// };
```
After:
```
struct MatchInfo
{
    bool found;
    std::vector<std::pair<size_t, size_t>> matches; // Stores all non-overlapping {start, end} pairs
};
```
## match_text_with_positions Function Rework:
This function has been substantially refactored to iterate through the input line, attempting to find a match starting from each possible character position.
It now uses a current_global_pos to track the absolute starting point in the original_input_text.
For each potential match, it creates a std::string_view of the remaining_text and runs the NFA simulation on this substring.
Upon finding a match, its global (start_pos, end_pos) are recorded in MatchInfo::matches, and current_global_pos is advanced past the entire matched segment (ensuring non-overlapping behavior and handling zero-length matches by advancing at least one character).
If no match is found from a current_global_pos, it advances by one character to try the next starting position.
(No direct code snippet here as it's a full function replacement, but you can reference the provided C++ changes in the commit.)
## print_with_color Function Update:
This function now iterates through the MatchInfo::matches vector.
It intelligently prints segments of the line: the part before the first match, then the first match in color, then the segment between the first and second match, then the second match in color, and so on. Any remaining text after the last match is printed in default color.
The if (!use_color || !match_info.found) condition remains to correctly handle lines with no matches or when coloring is disabled.